### PR TITLE
Update gatsby-ssr.js

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -2,8 +2,7 @@ import React from 'react';
 
 const getOptions = (pluginOptions) => {
   const plausibleDomain = pluginOptions.customDomain || 'plausible.io';
-  const scriptURI =
-    plausibleDomain === 'plausible.io' ? '/js/plausible.js' : '/js/index.js';
+  const scriptURI = '/js/plausible.js';
   const domain = pluginOptions.domain;
   const excludePaths = pluginOptions.excludePaths || [];
   const trackAcquisition = pluginOptions.trackAcquisition || false;


### PR DESCRIPTION
The self-hosted version of Plausible uses `/js/plausible.js` is the `scriptURI`, just like the cloud version. Updating this will resolve [issue #83](https://github.com/pixelplicity/gatsby-plugin-plausible/issues/83)